### PR TITLE
Support for Blue-green deploys and custom CF API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,47 @@
-# cloud-foundry-deploy step
+# cloud-foundry-deploy
 
-Required parameters can be set as deploy environment variables, OR as options
-under the step in the wercker.yml file.
+Deploys the current path to a cloud foundry instance. You
 
- - WERCKER_CLOUD_FOUNDRY_DEPLOY_USERNAME (or option of username)
- - WERCKER_CLOUD_FOUNDRY_DEPLOY_PASSWORD (or option of password)
- - WERCKER_CLOUD_FOUNDRY_DEPLOY_ORGANIZATION (or option of organization)
- - WERCKER_CLOUD_FOUNDRY_DEPLOY_SPACE (or option of space, defaults to development)
- - WERCKER_CLOUD_FOUNDRY_DEPLOY_APPNAME (or option of appname, defaults to default_app)
- - WERCKER_CLOUD_FOUNDRY_DEPLOY_DOMAIN (or option of domain, defaults to cfapps.io)
+# What's new
+
+- Blue-Green Deploys.
+- Support for hosted cloud foundry instances
+
+# Options
+
+* `appname` (required) The application name.
+* `username` (required) Cloud Foundry Username.
+* `password` (required) Cloud Foundry Password.
+* `organization` (required) Cloud Foundry Organization.
+* `space` (required) Cloud Foundry Space.
+* `alt_appname` (optional) Alternative application name for blue-green deploys.
+* `domain` (optional) App domain.
+* `route` (optional, required for blue-green deploys) App route.
+* `api` (optional, default: `https://api.run.pivotal.io`) Cloud Foundry API endpoint.
+* `skip_ssl` (optional) Skip ssl validation on API login.
+
+# Example
+
+Deploy to cloud foundry:
+
+```yaml
+steps:
+  - USERNAME/cloud-foundry-deploy
+...
+deploy:
+  steps:
+    - dlapiduz/cloud-foundry-deploy:
+      api: $CF_API # Set as environment variables
+      username: $CF_USER
+      password: $CF_PASS
+      organization: $CF_ORG
+      space: $CF_SPACE
+      appname: myapp-green
+      alt_appname: myapp-blue
+      route: default_app.cfapps.io
+
+```
+
+# License
+
+The MIT License (MIT)

--- a/run.sh
+++ b/run.sh
@@ -1,40 +1,97 @@
-ruby -v
-wget http://go-cli.s3-website-us-east-1.amazonaws.com/releases/v6.3.2/cf-linux-amd64.tgz
-tar -zxvf cf-linux-amd64.tgz
-./cf api https://api.run.pivotal.io
+simple_deploy() {
+  set -e;
+  local appname="$1";
+  local domain="$2";
 
-appname=${WERCKER_CLOUD_FOUNDRY_DEPLOY_APPNAME-default_app}
-username=$WERCKER_CLOUD_FOUNDRY_DEPLOY_USERNAME
-password=$WERCKER_CLOUD_FOUNDRY_DEPLOY_PASSWORD
-organization=$WERCKER_CLOUD_FOUNDRY_DEPLOY_ORGANIZATION
-space=${WERCKER_CLOUD_FOUNDRY_DEPLOY_SPACE-development}
-domain=${WERCKER_CLOUD_FOUNDRY_DEPLOY_DOMAIN-cfapps.io}
-host=${WERCKER_CLOUD_FOUNDRY_DEPLOY_HOST-$appname}
+  local push_cmd="./cf push $appname";
 
-./cf login -u $username -p $password -o $organization -s $space
+  if [ -n "$domain" ]; then
+    push_cmd="$push_cmd -d $domain";
+  fi;
 
-# Basic blue-green here
-if $(./cf app $appname-a | grep -q started)
-then
-  OLD="$appname-a"
-  NEW="$appname-b"
-else
-  OLD="$appname-b"
-  NEW="$appname-a"
-fi
+  eval $push_cmd;
+}
 
-echo "Pushing new app to $NEW and disabling $OLD"
-./cf push $NEW  -d $domain -n $host
-if [[ $? -ne 0 ]]; then
-  echo "Error pushing"
-  ./cf stop $NEW
-  exit 1
-fi
+blue_green_deploy() {
+  local appname="$1";
+  local alt_appname="$2";
+  local route="$3";
 
-echo "Re-routing"
-./cf map-route $NEW $domain -n $appname
-./cf unmap-route $OLD $domain -n $appname
-./cf stop $OLD
+  if $(./cf app $appname | grep -q started); then
+    OLD="$appname";
+    NEW="$alt_appname";
+  else
+    OLD="$alt_appname";
+    NEW="$appname";
+  fi
 
-echo "Done"
+  info "Pushing new app to $NEW and disabling $OLD"
+  ./cf push $NEW
+  if [[ $? -ne 0 ]]; then
+    ./cf stop $NEW;
+    fail "Error pushing app";
+  fi
 
+  info "Re-routing"
+  ./cf map-route $NEW $route
+  ./cf unmap-route $OLD $route
+  ./cf stop $OLD
+}
+
+main() {
+  set -e;
+
+  # Assign global variables to local
+
+  local appname="$WERCKER_CLOUD_FOUNDRY_DEPLOY_APPNAME"
+  local alt_appname="$WERCKER_CLOUD_FOUNDRY_DEPLOY_ALT_APPNAME"
+  local username="$WERCKER_CLOUD_FOUNDRY_DEPLOY_USERNAME"
+  local password="$WERCKER_CLOUD_FOUNDRY_DEPLOY_PASSWORD"
+  local organization="$WERCKER_CLOUD_FOUNDRY_DEPLOY_ORGANIZATION"
+  local space="$WERCKER_CLOUD_FOUNDRY_DEPLOY_SPACE"
+  local domain="$WERCKER_CLOUD_FOUNDRY_DEPLOY_DOMAIN"
+  local route="$WERCKER_CLOUD_FOUNDRY_DEPLOY_ROUTE"
+  local api="$WERCKER_CLOUD_FOUNDRY_DEPLOY_API"
+  local skip_ssl="$WERCKER_CLOUD_FOUNDRY_DEPLOY_SKIP_SSL"
+
+  # Validate variables
+  if [ -z "$appname" ] || [ -z "$username" ] || [ -z "$password" ] || [ -z "$organization" ] || [ -z "$space" ] ; then
+    fail "appname, username, password, organization and space are required; please add them to the step";
+  fi
+
+  if [ -z "$api" ]; then
+    api="https://api.run.pivotal.io";
+    info "api not specified; using https://api.run.pivotal.io";
+  fi
+
+  info "Downloading CF CLI";
+  wget -O cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary";
+  tar -zxf cf.tgz;
+
+  info "Logging in to CF API";
+  local login_cmd="./cf login \
+      -u \"$username\" \
+      -p \"$password\" \
+      -o \"$organization\" \
+      -s \"$space\" \
+      -a \"$api\"";
+
+  if [ -n "$skip_ssl" ]; then
+    login_cmd="$login_cmd --skip-ssl-validation";
+  fi
+  eval $login_cmd;
+
+  if [ -n "$alt_appname" ]; then
+    info "Doing Blue-green deploy with $appname and $alt_appname";
+    if [ -z "$route" ]; then
+      fail "route not specified; it is required for blue-green deploys; please add the route parameter to the step";
+    fi
+    blue_green_deploy "$appname" "$alt_appname" "$route";
+  else
+    info "Pushing app";
+    simple_deploy "$appname" "$domain";
+  fi
+}
+
+# Run the main function
+main;

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,3 +1,3 @@
 name: cloud-foundry-deploy
-version: 1.2.3
+version: 1.2.4
 description: cloud-foundry-deploy step

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,3 +1,3 @@
 name: cloud-foundry-deploy
-version: 1.2.4
+version: 2.0.6
 description: cloud-foundry-deploy step


### PR DESCRIPTION
A couple changes to the step:
- Blue-green deploys are paremetrized
- Allow simple `cf push` too
- Support for custom CF API endpoint
- Add more readme docs
- Add MIT license
